### PR TITLE
Update the version of markdown2clj to the latest version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,5 +7,5 @@
                  [org.docx4j/docx4j   "3.2.2"]
                  [net.sourceforge.cssparser/cssparser "0.9.18"]
                  [org.w3c.css/sac "1.3"]
-                 [markdown2clj "0.1.2-SNAPSHOT"]]
+                 [markdown2clj "0.1.3"]]
   :main markdown2docx.core)

--- a/src/markdown2docx/core.clj
+++ b/src/markdown2docx/core.clj
@@ -5,7 +5,7 @@
 
 (defn -main [& [md-file docx-file css-file]]
   (let [md-string (slurp md-file)
-        md-map (md/parse md-string true)
+        md-map (md/parse md-string :parse-tabbed-tables)
         css-string (if (not (nil? css-file))
                      (slurp css-file)
                      "")


### PR DESCRIPTION
- updated the version of the `markdown2clj` to `0.1.3`
